### PR TITLE
20106: Handle tuple response from engine

### DIFF
--- a/src/client/wasm/index.ts
+++ b/src/client/wasm/index.ts
@@ -2,4 +2,4 @@ export * from "./client.js";
 export * from "./files.js";
 export * from "../errors.js";
 export * from "../../trainees/index.js";
-export { AmalgamCoreError, AmalgamCoreWarning, AmalgamCoreResponse } from "./core.js";
+export { AmalgamCoreError, AmalgamCoreResponse } from "./core.js";


### PR DESCRIPTION
The howso-engine will now return a tuple of `[is_success, payload]` as its response. Update parsing this response object in the client.

Format:
```
// Success
[
    1,
    {
        "warnings": ["a str message", ...], // optional warnings
        "payload": Any
    }
]


// Error
[  
    0,
    {
        "detail": "single message" || ["or a list of messages", ...],
        "code": "validation", // optional error code
        "errors": { // optional field validation errors
            "complex_object": {
                "nested": {
                    "value": [
                        {
                            "message": "Value is not a valid integer.",
                            "code": "type_error.integer" // optional error code
                        }
                    ]
                },
            }
            "name": [
                {
                    "message": "Field required.",
                    "code": "missing"
                }
            ],
        }
    }
]
```